### PR TITLE
changed the GET /course route to GET /course/:courseid

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -13,7 +13,7 @@ app.use(express.static(path.join(__dirname, '../public')));
 
 app.get('/', (req, res) => res.render('index.html'));
 
-app.get('/course', (req, res) => {
+app.get('/course/:courseId', (req, res) => {
   Course.findCourseById(req.body.courseId)
   .then((course) => {
     res.send(course);


### PR DESCRIPTION
courseid query param will now be encoded in the url of the GET requests.